### PR TITLE
Release v0.1.1 of cargo-quickstart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ target/
 .idea/
 .DS_Store
 .bacon-locations
+memory-bank/
+.cursor/
 
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ target/
 **/*.rs.bk
 *.log
 .idea/
-.DS_Store
+**/.DS_Store
 .bacon-locations
 memory-bank/
 .cursor/

--- a/crates/quickstart-cli/CHANGELOG.md
+++ b/crates/quickstart-cli/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <csr-read-only-do-not-edit/>
 
- - 12 commits contributed to the release over the course of 4 calendar days.
+ - 13 commits contributed to the release over the course of 4 calendar days.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <details><summary>view details</summary>
 
  * **Uncategorized**
+    - Adjusting changelogs prior to release of cargo-quickstart v0.1.1 ([`6986bf6`](https://github.com/sm-moshi/cargo-quickstart/commit/6986bf6a69824e061b5b758930cdccbdb9ee0224))
     - Adjusting changelogs prior to release of cargo-quickstart v0.1.1 ([`951cce5`](https://github.com/sm-moshi/cargo-quickstart/commit/951cce549f7d495b85d7e31f43cb659bc7874e2a))
     - Adjusting changelogs prior to release of cargo-quickstart v0.1.1 ([`f5a171d`](https://github.com/sm-moshi/cargo-quickstart/commit/f5a171d237d68869f979431dd429d6c09826b5d6))
     - Adjusting changelogs prior to release of cargo-quickstart v0.1.1 ([`70ce637`](https://github.com/sm-moshi/cargo-quickstart/commit/70ce63710152954b3cc71ef64c4f055b797f3bd0))

--- a/crates/quickstart-cli/CHANGELOG.md
+++ b/crates/quickstart-cli/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <csr-read-only-do-not-edit/>
 
- - 10 commits contributed to the release over the course of 4 calendar days.
+ - 11 commits contributed to the release over the course of 4 calendar days.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <details><summary>view details</summary>
 
  * **Uncategorized**
+    - Adjusting changelogs prior to release of cargo-quickstart v0.1.1 ([`720363c`](https://github.com/sm-moshi/cargo-quickstart/commit/720363cf09f301a8618f406282964372a308cf68))
     - Adjusting changelogs prior to release of cargo-quickstart v0.1.1 ([`70ce637`](https://github.com/sm-moshi/cargo-quickstart/commit/70ce63710152954b3cc71ef64c4f055b797f3bd0))
     - Release quickstart-lib v0.1.1 ([`ec24ba5`](https://github.com/sm-moshi/cargo-quickstart/commit/ec24ba55ff381af38a5967ac0ef56549fad8abe6))
     - Quickstart v0.1.1 CHANGELOG.md ([`8eb8066`](https://github.com/sm-moshi/cargo-quickstart/commit/8eb80663c3487d76920318064eb4ca63b671765c))

--- a/crates/quickstart-cli/CHANGELOG.md
+++ b/crates/quickstart-cli/CHANGELOG.md
@@ -5,15 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.1.1 (2025-05-05)
 
 ### Commit Statistics
 
 <csr-read-only-do-not-edit/>
 
--   7 commits contributed to the release over the course of 4 calendar days.
--   0 commits were understood as [conventional](https://www.conventionalcommits.org).
--   0 issues like '(#ID)' were seen in commit messages
+ - 9 commits contributed to the release over the course of 4 calendar days.
+ - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
+ - 0 issues like '(#ID)' were seen in commit messages
 
 ### Commit Details
 
@@ -21,5 +21,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <details><summary>view details</summary>
 
--   **Uncategorized** - Release v0.1.1 ([`a860321`](https://github.com/sm-moshi/cargo-quickstart/commit/a860321fe0dd17fbf9ac60e6a726ec78b4fda380)) - ~v0.1.1 ([`236bc17`](https://github.com/sm-moshi/cargo-quickstart/commit/236bc172bd592c9258b720e1ea9139cb4900c284)) - ~ ([`8351aaf`](https://github.com/sm-moshi/cargo-quickstart/commit/8351aaf214370f7fb7b96c2984c437ce2cc85340)) - Preparing v0.1.0 ([`d640d9f`](https://github.com/sm-moshi/cargo-quickstart/commit/d640d9fe5647aca15e28c45bfc75130bdf3b06be)) - Meow ([`f3b283c`](https://github.com/sm-moshi/cargo-quickstart/commit/f3b283ca4b0e67f9c3a5e707d56a05cb70f0df3c)) - Merge branch 'main' into develop ([`999b399`](https://github.com/sm-moshi/cargo-quickstart/commit/999b399048c5a8ca885d7627535299557c83f83b)) - Sorry. quickstart-cli was missing. ([`25f5c34`](https://github.com/sm-moshi/cargo-quickstart/commit/25f5c34d2bb2260693a856dc953c982406ee2a37))
+ * **Uncategorized**
+    - Release quickstart-lib v0.1.1 ([`ec24ba5`](https://github.com/sm-moshi/cargo-quickstart/commit/ec24ba55ff381af38a5967ac0ef56549fad8abe6))
+    - Quickstart v0.1.1 CHANGELOG.md ([`8eb8066`](https://github.com/sm-moshi/cargo-quickstart/commit/8eb80663c3487d76920318064eb4ca63b671765c))
+    - Release v0.1.1 ([`a860321`](https://github.com/sm-moshi/cargo-quickstart/commit/a860321fe0dd17fbf9ac60e6a726ec78b4fda380))
+    - ~v0.1.1 ([`236bc17`](https://github.com/sm-moshi/cargo-quickstart/commit/236bc172bd592c9258b720e1ea9139cb4900c284))
+    - ~ ([`8351aaf`](https://github.com/sm-moshi/cargo-quickstart/commit/8351aaf214370f7fb7b96c2984c437ce2cc85340))
+    - Preparing v0.1.0 ([`d640d9f`](https://github.com/sm-moshi/cargo-quickstart/commit/d640d9fe5647aca15e28c45bfc75130bdf3b06be))
+    - Meow ([`f3b283c`](https://github.com/sm-moshi/cargo-quickstart/commit/f3b283ca4b0e67f9c3a5e707d56a05cb70f0df3c))
+    - Merge branch 'main' into develop ([`999b399`](https://github.com/sm-moshi/cargo-quickstart/commit/999b399048c5a8ca885d7627535299557c83f83b))
+    - Sorry. quickstart-cli was missing. ([`25f5c34`](https://github.com/sm-moshi/cargo-quickstart/commit/25f5c34d2bb2260693a856dc953c982406ee2a37))
 </details>
+

--- a/crates/quickstart-cli/CHANGELOG.md
+++ b/crates/quickstart-cli/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <csr-read-only-do-not-edit/>
 
- - 9 commits contributed to the release over the course of 4 calendar days.
+ - 10 commits contributed to the release over the course of 4 calendar days.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <details><summary>view details</summary>
 
  * **Uncategorized**
+    - Adjusting changelogs prior to release of cargo-quickstart v0.1.1 ([`70ce637`](https://github.com/sm-moshi/cargo-quickstart/commit/70ce63710152954b3cc71ef64c4f055b797f3bd0))
     - Release quickstart-lib v0.1.1 ([`ec24ba5`](https://github.com/sm-moshi/cargo-quickstart/commit/ec24ba55ff381af38a5967ac0ef56549fad8abe6))
     - Quickstart v0.1.1 CHANGELOG.md ([`8eb8066`](https://github.com/sm-moshi/cargo-quickstart/commit/8eb80663c3487d76920318064eb4ca63b671765c))
     - Release v0.1.1 ([`a860321`](https://github.com/sm-moshi/cargo-quickstart/commit/a860321fe0dd17fbf9ac60e6a726ec78b4fda380))

--- a/crates/quickstart-cli/CHANGELOG.md
+++ b/crates/quickstart-cli/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Commit Statistics
+
+<csr-read-only-do-not-edit/>
+
+-   7 commits contributed to the release over the course of 4 calendar days.
+-   0 commits were understood as [conventional](https://www.conventionalcommits.org).
+-   0 issues like '(#ID)' were seen in commit messages
+
+### Commit Details
+
+<csr-read-only-do-not-edit/>
+
+<details><summary>view details</summary>
+
+-   **Uncategorized** - Release v0.1.1 ([`a860321`](https://github.com/sm-moshi/cargo-quickstart/commit/a860321fe0dd17fbf9ac60e6a726ec78b4fda380)) - ~v0.1.1 ([`236bc17`](https://github.com/sm-moshi/cargo-quickstart/commit/236bc172bd592c9258b720e1ea9139cb4900c284)) - ~ ([`8351aaf`](https://github.com/sm-moshi/cargo-quickstart/commit/8351aaf214370f7fb7b96c2984c437ce2cc85340)) - Preparing v0.1.0 ([`d640d9f`](https://github.com/sm-moshi/cargo-quickstart/commit/d640d9fe5647aca15e28c45bfc75130bdf3b06be)) - Meow ([`f3b283c`](https://github.com/sm-moshi/cargo-quickstart/commit/f3b283ca4b0e67f9c3a5e707d56a05cb70f0df3c)) - Merge branch 'main' into develop ([`999b399`](https://github.com/sm-moshi/cargo-quickstart/commit/999b399048c5a8ca885d7627535299557c83f83b)) - Sorry. quickstart-cli was missing. ([`25f5c34`](https://github.com/sm-moshi/cargo-quickstart/commit/25f5c34d2bb2260693a856dc953c982406ee2a37))
+</details>

--- a/crates/quickstart-cli/CHANGELOG.md
+++ b/crates/quickstart-cli/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <csr-read-only-do-not-edit/>
 
- - 11 commits contributed to the release over the course of 4 calendar days.
+ - 12 commits contributed to the release over the course of 4 calendar days.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -22,7 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <details><summary>view details</summary>
 
  * **Uncategorized**
-    - Adjusting changelogs prior to release of cargo-quickstart v0.1.1 ([`720363c`](https://github.com/sm-moshi/cargo-quickstart/commit/720363cf09f301a8618f406282964372a308cf68))
+    - Adjusting changelogs prior to release of cargo-quickstart v0.1.1 ([`951cce5`](https://github.com/sm-moshi/cargo-quickstart/commit/951cce549f7d495b85d7e31f43cb659bc7874e2a))
+    - Adjusting changelogs prior to release of cargo-quickstart v0.1.1 ([`f5a171d`](https://github.com/sm-moshi/cargo-quickstart/commit/f5a171d237d68869f979431dd429d6c09826b5d6))
     - Adjusting changelogs prior to release of cargo-quickstart v0.1.1 ([`70ce637`](https://github.com/sm-moshi/cargo-quickstart/commit/70ce63710152954b3cc71ef64c4f055b797f3bd0))
     - Release quickstart-lib v0.1.1 ([`ec24ba5`](https://github.com/sm-moshi/cargo-quickstart/commit/ec24ba55ff381af38a5967ac0ef56549fad8abe6))
     - Quickstart v0.1.1 CHANGELOG.md ([`8eb8066`](https://github.com/sm-moshi/cargo-quickstart/commit/8eb80663c3487d76920318064eb4ca63b671765c))

--- a/crates/quickstart-cli/Cargo.toml
+++ b/crates/quickstart-cli/Cargo.toml
@@ -33,7 +33,7 @@ dialoguer = { workspace = true, default-features = false }
 indicatif = { workspace = true, default-features = false }
 console = { workspace = true }
 clap_complete = { workspace = true, optional = true }
-quickstart-lib = { path = "../quickstart-lib", version = "=0.1.1" }
+quickstart-lib = { path = "../quickstart-lib", version = "0.1.1" }
 which = { workspace = true, default-features = false, optional = true }
 thiserror = { workspace = true }
 libc = { workspace = true }
@@ -44,4 +44,4 @@ mockall = { workspace = true }
 predicates = { workspace = true, default-features = false }
 pretty_assertions = { workspace = true }
 tempfile = { workspace = true }
-quickstart-lib = { path = "../quickstart-lib", features = ["test-utils"], version = "=0.1.1" }
+quickstart-lib = { path = "../quickstart-lib", features = ["test-utils"], version = "0.1.1" }

--- a/crates/quickstart-cli/Cargo.toml
+++ b/crates/quickstart-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-quickstart"
-version.workspace = true
+version = "0.1.1"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/quickstart-cli/Cargo.toml
+++ b/crates/quickstart-cli/Cargo.toml
@@ -33,7 +33,7 @@ dialoguer = { workspace = true, default-features = false }
 indicatif = { workspace = true, default-features = false }
 console = { workspace = true }
 clap_complete = { workspace = true, optional = true }
-quickstart-lib = { path = "../quickstart-lib", version = "0.1.1" }
+quickstart-lib = { path = "../quickstart-lib", version = "^0.1.1" }
 which = { workspace = true, default-features = false, optional = true }
 thiserror = { workspace = true }
 libc = { workspace = true }
@@ -44,4 +44,4 @@ mockall = { workspace = true }
 predicates = { workspace = true, default-features = false }
 pretty_assertions = { workspace = true }
 tempfile = { workspace = true }
-quickstart-lib = { path = "../quickstart-lib", features = ["test-utils"], version = "0.1.1" }
+quickstart-lib = { path = "../quickstart-lib", features = ["test-utils"], version = "^0.1.1" }

--- a/crates/quickstart-lib/CHANGELOG.md
+++ b/crates/quickstart-lib/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.1.1 (2025-05-05)
 
 ### Documentation
 
@@ -15,25 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    This commit updates documentation to reflect the completed CLI implementation:
    
    -   Update memory bank files with current project status
-   
-   -   Document CLI framework completion in activeContext.md
--   Update progress.md with component completion status
--   Record testing approach and infrastructure details
--   Mark completed items in ROADMAP.md and TODO.md
--   Add comprehensive CHANGELOG.md entries for implemented features
--   Document test coverage details and approach
--   Add new sections for interactive UI and testing improvements
--   Update memory bank files with current project status
-
-        -   Document CLI framework completion in activeContext.md
-        -   Update progress.md with component completion status
-        -   Record testing approach and infrastructure details
--   Update progress.md with component completion status
--   Record testing approach and infrastructure details
--   Mark completed items in ROADMAP.md and TODO.md
--   Add comprehensive CHANGELOG.md entries for implemented features
--   Document test coverage details and approach
--   Add new sections for interactive UI and testing improvements
+-   Document CLI framework completion in activeContext.md
 
 ### New Features
 
@@ -44,38 +26,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    This commit implements the complete CLI functionality including:
    
    -   Full argument parsing with clap for new/init commands
--   Interactive prompts with dialoguer for user input
--   Project generation with proper error handling
--   Comprehensive test suite with:
-        -   Unit tests for internal functions
-        -   Integration tests with assert_cmd
-        -   Test fixtures for validation and mocking
-        -   Coverage reporting (74% line coverage)
--   Integration tests with assert_cmd
--   Test fixtures for validation and mocking
--   Coverage reporting (74% line coverage)
--   Full argument parsing with clap for new/init commands
--   Interactive prompts with dialoguer for user input
--   Project generation with proper error handling
--   Comprehensive test suite with:
-        -   Unit tests for internal functions
-        -   Integration tests with assert_cmd
-        -   Test fixtures for validation and mocking
-        -   Coverage reporting (74% line coverage)
--   Integration tests with assert_cmd
--   Test fixtures for validation and mocking
--   Coverage reporting (74% line coverage)
--   Full argument parsing with clap for new/init commands
--   Interactive prompts with dialoguer for user input
--   Project generation with proper error handling
--   Comprehensive test suite with:
-        -   Unit tests for internal functions
-        -   Integration tests with assert_cmd
-        -   Test fixtures for validation and mocking
-        -   Coverage reporting (74% line coverage)
--   Integration tests with assert_cmd
--   Test fixtures for validation and mocking
--   Coverage reporting (74% line coverage)
 
 ### Commit Statistics
 
@@ -92,7 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <details><summary>view details</summary>
 
  * **Uncategorized**
-    - Quickstart-lib v0.1.1 CHANGELOG.md ([`bbb6bd1`](https://github.com/sm-moshi/cargo-quickstart/commit/bbb6bd124cab25b0cb9dd1bb8d0d583defae8772))
+    - Quickstart v0.1.1 CHANGELOG.md ([`8eb8066`](https://github.com/sm-moshi/cargo-quickstart/commit/8eb80663c3487d76920318064eb4ca63b671765c))
     - ~v0.1.1 ([`236bc17`](https://github.com/sm-moshi/cargo-quickstart/commit/236bc172bd592c9258b720e1ea9139cb4900c284))
     - Preparing v0.1.0 ([`d640d9f`](https://github.com/sm-moshi/cargo-quickstart/commit/d640d9fe5647aca15e28c45bfc75130bdf3b06be))
     - Meow ([`f3b283c`](https://github.com/sm-moshi/cargo-quickstart/commit/f3b283ca4b0e67f9c3a5e707d56a05cb70f0df3c))
@@ -108,5 +58,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 </details>
 
 <csr-unknown>
-Enhance documentation filesThe documentation now accurately reflects the project’s ~74% test coverageand completed CLI framework with interactive components. update project documentation and memory bankThis commit updates documentation to reflect the completed CLI implementation:Enhance documentation filesThe documentation now accurately reflects the project’s ~74% test coverageand completed CLI framework with interactive components.The implementation includes proper error propagation, separation of concerns between UI and logic, and follows idiomatic Rust patterns.All tests pass with appropriate use of mocking for code that requires user interaction. implement CLI scaffolding with robust test coverageThis commit implements the complete CLI functionality including:The implementation includes proper error propagation, separation of concerns between UI and logic, and follows idiomatic Rust patterns.All tests pass with appropriate use of mocking for code that requires user interaction. implement CLI scaffolding with robust test coverageThis commit implements the complete CLI functionality including:The implementation includes proper error propagation, separation of concerns between UI and logic, and follows idiomatic Rust patterns.All tests pass with appropriate use of mocking for code that requires user interaction.<csr-unknown/>
+Update progress.md with component completion statusRecord testing approach and infrastructure detailsMark completed items in ROADMAP.md and TODO.mdAdd comprehensive CHANGELOG.md entries for implemented featuresDocument test coverage details and approachAdd new sections for interactive UI and testing improvementsUpdate memory bank files with current project status-   Document CLI framework completion in activeContext.md
+-   Update progress.md with component completion status
+-   Record testing approach and infrastructure details
+Update progress.md with component completion statusRecord testing approach and infrastructure detailsMark completed items in ROADMAP.md and TODO.mdAdd comprehensive CHANGELOG.md entries for implemented featuresDocument test coverage details and approachAdd new sections for interactive UI and testing improvementsInteractive prompts with dialoguer for user inputProject generation with proper error handlingComprehensive test suite with:-   Unit tests for internal functions-   Integration tests with assert_cmd-   Test fixtures for validation and mocking-   Coverage reporting (74% line coverage)Integration tests with assert_cmdTest fixtures for validation and mockingCoverage reporting (74% line coverage)Full argument parsing with clap for new/init commandsInteractive prompts with dialoguer for user inputProject generation with proper error handlingComprehensive test suite with:-   Unit tests for internal functions-   Integration tests with assert_cmd-   Test fixtures for validation and mocking-   Coverage reporting (74% line coverage)Integration tests with assert_cmdTest fixtures for validation and mockingCoverage reporting (74% line coverage)Full argument parsing with clap for new/init commandsInteractive prompts with dialoguer for user inputProject generation with proper error handlingComprehensive test suite with:-   Unit tests for internal functions-   Integration tests with assert_cmd-   Test fixtures for validation and mocking-   Coverage reporting (74% line coverage)Integration tests with assert_cmdTest fixtures for validation and mockingCoverage reporting (74% line coverage)<csr-unknown/>
 

--- a/crates/quickstart-lib/CHANGELOG.md
+++ b/crates/quickstart-lib/CHANGELOG.md
@@ -1,0 +1,112 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Documentation
+
+<csr-id-2e67d36371c90fabe1cc5fb2625d958a93347db9/>
+
+ - <csr-id-1868c3db08e351db2940fadc77b829ae41ebe9a6/> update project documentation and memory bank
+   This commit updates documentation to reflect the completed CLI implementation:
+   
+   -   Update memory bank files with current project status
+   
+   -   Document CLI framework completion in activeContext.md
+-   Update progress.md with component completion status
+-   Record testing approach and infrastructure details
+-   Mark completed items in ROADMAP.md and TODO.md
+-   Add comprehensive CHANGELOG.md entries for implemented features
+-   Document test coverage details and approach
+-   Add new sections for interactive UI and testing improvements
+-   Update memory bank files with current project status
+
+        -   Document CLI framework completion in activeContext.md
+        -   Update progress.md with component completion status
+        -   Record testing approach and infrastructure details
+-   Update progress.md with component completion status
+-   Record testing approach and infrastructure details
+-   Mark completed items in ROADMAP.md and TODO.md
+-   Add comprehensive CHANGELOG.md entries for implemented features
+-   Document test coverage details and approach
+-   Add new sections for interactive UI and testing improvements
+
+### New Features
+
+<csr-id-ceaf9105d688626479b9defea548860e20b137cd/>
+<csr-id-83197cce409fdd189ef3b412760ba3cabcfaf11d/>
+
+ - <csr-id-e5b2b9bbfea532e9f53e91294d74371df239309c/> implement CLI scaffolding with robust test coverage
+   This commit implements the complete CLI functionality including:
+   
+   -   Full argument parsing with clap for new/init commands
+-   Interactive prompts with dialoguer for user input
+-   Project generation with proper error handling
+-   Comprehensive test suite with:
+        -   Unit tests for internal functions
+        -   Integration tests with assert_cmd
+        -   Test fixtures for validation and mocking
+        -   Coverage reporting (74% line coverage)
+-   Integration tests with assert_cmd
+-   Test fixtures for validation and mocking
+-   Coverage reporting (74% line coverage)
+-   Full argument parsing with clap for new/init commands
+-   Interactive prompts with dialoguer for user input
+-   Project generation with proper error handling
+-   Comprehensive test suite with:
+        -   Unit tests for internal functions
+        -   Integration tests with assert_cmd
+        -   Test fixtures for validation and mocking
+        -   Coverage reporting (74% line coverage)
+-   Integration tests with assert_cmd
+-   Test fixtures for validation and mocking
+-   Coverage reporting (74% line coverage)
+-   Full argument parsing with clap for new/init commands
+-   Interactive prompts with dialoguer for user input
+-   Project generation with proper error handling
+-   Comprehensive test suite with:
+        -   Unit tests for internal functions
+        -   Integration tests with assert_cmd
+        -   Test fixtures for validation and mocking
+        -   Coverage reporting (74% line coverage)
+-   Integration tests with assert_cmd
+-   Test fixtures for validation and mocking
+-   Coverage reporting (74% line coverage)
+
+### Commit Statistics
+
+<csr-read-only-do-not-edit/>
+
+ - 13 commits contributed to the release over the course of 5 calendar days.
+ - 5 commits were understood as [conventional](https://www.conventionalcommits.org).
+ - 0 issues like '(#ID)' were seen in commit messages
+
+### Commit Details
+
+<csr-read-only-do-not-edit/>
+
+<details><summary>view details</summary>
+
+ * **Uncategorized**
+    - Quickstart-lib v0.1.1 CHANGELOG.md ([`bbb6bd1`](https://github.com/sm-moshi/cargo-quickstart/commit/bbb6bd124cab25b0cb9dd1bb8d0d583defae8772))
+    - ~v0.1.1 ([`236bc17`](https://github.com/sm-moshi/cargo-quickstart/commit/236bc172bd592c9258b720e1ea9139cb4900c284))
+    - Preparing v0.1.0 ([`d640d9f`](https://github.com/sm-moshi/cargo-quickstart/commit/d640d9fe5647aca15e28c45bfc75130bdf3b06be))
+    - Meow ([`f3b283c`](https://github.com/sm-moshi/cargo-quickstart/commit/f3b283ca4b0e67f9c3a5e707d56a05cb70f0df3c))
+    - Merge branch 'main' into develop ([`999b399`](https://github.com/sm-moshi/cargo-quickstart/commit/999b399048c5a8ca885d7627535299557c83f83b))
+    - Implement CLI scaffolding with robust test coverage ([`e5b2b9b`](https://github.com/sm-moshi/cargo-quickstart/commit/e5b2b9bbfea532e9f53e91294d74371df239309c))
+    - Update project documentation and memory bank ([`1868c3d`](https://github.com/sm-moshi/cargo-quickstart/commit/1868c3db08e351db2940fadc77b829ae41ebe9a6))
+    - Implement CLI scaffolding with robust test coverage ([`ceaf910`](https://github.com/sm-moshi/cargo-quickstart/commit/ceaf9105d688626479b9defea548860e20b137cd))
+    - INIT! ([`89bb640`](https://github.com/sm-moshi/cargo-quickstart/commit/89bb640aa132cd57f1fb4c4c40308f0b9473e4ff))
+    - Merge branch 'release/v0.0.1' into develop ([`b2ea7df`](https://github.com/sm-moshi/cargo-quickstart/commit/b2ea7dff4daf97a944302e2af9c4bea166befd54))
+    - Update project documentation and memory bank ([`2e67d36`](https://github.com/sm-moshi/cargo-quickstart/commit/2e67d36371c90fabe1cc5fb2625d958a93347db9))
+    - Implement CLI scaffolding with robust test coverage ([`83197cc`](https://github.com/sm-moshi/cargo-quickstart/commit/83197cce409fdd189ef3b412760ba3cabcfaf11d))
+    - INIT! ([`6039553`](https://github.com/sm-moshi/cargo-quickstart/commit/603955322f238fddba117ab02aa14466dfe707aa))
+</details>
+
+<csr-unknown>
+Enhance documentation filesThe documentation now accurately reflects the project’s ~74% test coverageand completed CLI framework with interactive components. update project documentation and memory bankThis commit updates documentation to reflect the completed CLI implementation:Enhance documentation filesThe documentation now accurately reflects the project’s ~74% test coverageand completed CLI framework with interactive components.The implementation includes proper error propagation, separation of concerns between UI and logic, and follows idiomatic Rust patterns.All tests pass with appropriate use of mocking for code that requires user interaction. implement CLI scaffolding with robust test coverageThis commit implements the complete CLI functionality including:The implementation includes proper error propagation, separation of concerns between UI and logic, and follows idiomatic Rust patterns.All tests pass with appropriate use of mocking for code that requires user interaction. implement CLI scaffolding with robust test coverageThis commit implements the complete CLI functionality including:The implementation includes proper error propagation, separation of concerns between UI and logic, and follows idiomatic Rust patterns.All tests pass with appropriate use of mocking for code that requires user interaction.<csr-unknown/>
+

--- a/crates/quickstart-lib/CHANGELOG.md
+++ b/crates/quickstart-lib/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    This commit updates documentation to reflect the completed CLI implementation:
    
    -   Update memory bank files with current project status
--   Document CLI framework completion in activeContext.md
+   -   Document CLI framework completion in activeContext.md
 
 ### New Features
 

--- a/crates/quickstart-lib/Cargo.toml
+++ b/crates/quickstart-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quickstart-lib"
-version.workspace = true
+version = "0.1.1"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,8 +12,6 @@ All notable changes to this project will be documented here.
 
 ### Changed
 
-- *No unreleased changes yet*
-
 ### Fixed
 
 - *No unreleased changes yet*

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,22 @@ All notable changes to this project will be documented here.
 
 ### Changed
 
+- *No unreleased changes yet*
+
+### Fixed
+
+- *No unreleased changes yet*
+
+⸻
+
+## [v0.1.1]
+
+### Added
+
+- Exact version specifications between workspace crates to ensure consistent builds on crates.io
+
+### Changed
+
 - CI workflows now use `Leafwing-Studios/cargo-cache` for more efficient Rust-specific caching
 - Updated from deprecated `actions-rs/toolchain` to `crusty-pie/toolchain`
 - Replaced `lazy_static` dependency with standard library's `std::sync::LazyLock`


### PR DESCRIPTION
Hey,

yeh. Haven't really done this yet, but this is supposed to be the barely working first release of my cargo-quickstart project.

There isn't really a big difference to v0.1.0, but...

- CI workflows now use Leafwing-Studios/cargo-cache for more efficient Rust-specific caching
- Updated from deprecated actions-rs/toolchain to crusty-pie/toolchain
- Replaced lazy_static dependency with standard library's std::sync::LazyLock
- Changed version requirements from exact (=0.1.1) to compatible (^0.1.1) for better flexibility
- Path validation now properly checks if parent directories exist before attempting to create project directories
- Added clear error messages for invalid paths to improve user experience

Hope this works out.