### PR TITLE
GHSA-735f-pc8j-v9w8: removed protobuf 2.28.0 dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,7 +221,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cargo-quickstart"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -808,9 +808,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbd780fe5cc30f81464441920d82ac8740e2e46b29a6fad543ddd075229ce37e"
+checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
 
 [[package]]
 name = "iana-time-zone"
@@ -1262,8 +1262,6 @@ dependencies = [
  "nix",
  "once_cell",
  "parking_lot",
- "protobuf",
- "protobuf-codegen-pure",
  "smallvec",
  "symbolic-demangle",
  "tempfile",
@@ -1317,31 +1315,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "protobuf"
-version = "2.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
-
-[[package]]
-name = "protobuf-codegen"
-version = "2.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "033460afb75cf755fcfc16dfaed20b86468082a2ea24e05ac35ab4a099a017d6"
-dependencies = [
- "protobuf",
-]
-
-[[package]]
-name = "protobuf-codegen-pure"
-version = "2.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a29399fc94bcd3eeaa951c715f7bea69409b2445356b00519740bcd6ddd865"
-dependencies = [
- "protobuf",
- "protobuf-codegen",
-]
-
-[[package]]
 name = "quick-xml"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1352,7 +1325,7 @@ dependencies = [
 
 [[package]]
 name = "quickstart-lib"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "chrono",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ inquire = { version = "0.7.5", default-features = false, features = ["crossterm"
 anyhow = { version = "1.0.98", default-features = false }
 criterion = { version = "0.5.1", default-features = false, features = ["html_reports"] }
 uuid = { version = "1.16.0", default-features = false, features = ["v4"] }
-pprof = { version = "0.14.0", features = ["flamegraph", "frame-pointer","criterion"] }
+pprof = { version = "0.14.0", features = ["flamegraph", "frame-pointer", "criterion"] }
 
 [profile.dev]
 codegen-units = 16

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ homepage = "https://github.com/sm-moshi/cargo-quickstart"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/sm-moshi/cargo-quickstart"
 rust-version = "1.82.0"
-version = "0.1.2"
+version = "0.1.3"
 
 [workspace.metadata]
 msrv = "1.82.0"
@@ -40,7 +40,7 @@ inquire = { version = "0.7.5", default-features = false, features = ["crossterm"
 anyhow = { version = "1.0.98", default-features = false }
 criterion = { version = "0.5.1", default-features = false, features = ["html_reports"] }
 uuid = { version = "1.16.0", default-features = false, features = ["v4"] }
-pprof = { version = "0.14.0", features = ["flamegraph", "frame-pointer", "protobuf-codec", "criterion"] }
+pprof = { version = "0.14.0", features = ["flamegraph", "frame-pointer","criterion"] }
 
 [profile.dev]
 codegen-units = 16

--- a/crates/quickstart-cli/Cargo.toml
+++ b/crates/quickstart-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-quickstart"
-version = "0.1.2"
+version = "0.1.3"
 authors.workspace = true
 edition = "2021"
 readme = "../../README.md"
@@ -33,7 +33,7 @@ color-eyre = { workspace = true, features = [], default-features = false }
 indicatif = { workspace = true, default-features = false }
 console = { workspace = true }
 clap_complete = { workspace = true, optional = true }
-quickstart-lib = { path = "../quickstart-lib", version = "^0.1.2" }
+quickstart-lib = { path = "../quickstart-lib", version = "^0.1.4" }
 which = { workspace = true, default-features = false, optional = true }
 thiserror = { workspace = true }
 libc = { workspace = true }
@@ -49,7 +49,7 @@ tempfile = { workspace = true }
 quickstart-lib = { path = "../quickstart-lib", features = ["test-utils"], version = "^0.1.3" }
 criterion = { workspace = true, default-features = false, features = ["html_reports"] }
 uuid = { workspace = true, default-features = false, features = ["v4"] }
-pprof = { workspace = true, features = ["flamegraph", "frame-pointer", "criterion", "protobuf-codec"] }
+pprof = { workspace = true, features = ["flamegraph", "frame-pointer", "criterion"] }
 
 [[bench]]
 name = "template_benchmarks"

--- a/crates/quickstart-lib/Cargo.toml
+++ b/crates/quickstart-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quickstart-lib"
-version = "0.1.3"
+version = "0.1.4"
 authors.workspace = true
 edition = "2021"
 readme = "../../README.md"


### PR DESCRIPTION
https://osv.dev/vulnerability/GHSA-735f-pc8j-v9w8

https://github.com/advisories/GHSA-735f-pc8j-v9w8
