### PR TITLE
deps(deps): bump clap_complete from 4.5.52 to 4.5.54

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -328,9 +328,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.52"
+version = "4.5.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a554639e42d0c838336fc4fbedb9e2df3ad1fa4acda149f9126b4ccfcd7900f"
+checksum = "aad5b1b4de04fead402672b48897030eec1f3bfe1550776322f59f6d6e6a5677"
 dependencies = [
  "clap",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ msrv = "1.82.0"
 [workspace.dependencies]
 assert_cmd = { version = "2.0.17", features = ["color"], default-features = false }
 clap = { version = "4.5.38", features = ["cargo", "derive", "std", "wrap_help", "error-context", "suggestions"], default-features = false }
-clap_complete = "4.5.52"
+clap_complete = "4.5.54"
 color-eyre = { version = "0.6.4", default-features = false }
 chrono = { version = "0.4.41", default-features = false }
 handlebars = { version = "6.3.2", default-features = false }


### PR DESCRIPTION
This pull request updates the version of the `clap_complete` dependency in the `Cargo.toml` file to ensure compatibility with the latest features and fixes.

* Dependency update:
  * Updated `clap_complete` from version `4.5.52` to `4.5.54` in `Cargo.toml`.Bumps [clap_complete](https://github.com/clap-rs/clap) from 4.5.52 to 4.5.54.
- [Release notes](https://github.com/clap-rs/clap/releases)
- [Changelog](https://github.com/clap-rs/clap/blob/master/CHANGELOG.md)
- [Commits](https://github.com/clap-rs/clap/compare/clap_complete-v4.5.52...clap_complete-v4.5.54)

---
updated-dependencies:
- dependency-name: clap_complete dependency-version: 4.5.54 dependency-type: direct:production update-type: version-update:semver-patch ...